### PR TITLE
Update grants.md

### DIFF
--- a/doc/grants.md
+++ b/doc/grants.md
@@ -1,0 +1,44 @@
+# Grants
+
+[More ideas here](https://intranet.uclouvain.be/en/myucl/administrations/adre/research-funding-opportunities.html)
+
+
+Contact person at UCL can help a lot: A.D.
+
+Credits / money for PhD students is rolled over from one year to the next
+
+## Travel
+
+### FNRS
+
+
+2 months in advance for within EU, 3 months for outside EU
+
+
+**don’t need to be FNRS to apply**
+
+
+Provide max. 2 conference grants per institute
+
+[FNRS Mobilité](https://www.frs-fnrs.be/fr/financements/mobilite-monde)
+
+**PLEASE NOTE they deadline is very strict! No possibility to apply if you miss the deadline**
+
+### IPSY
+
+[IPSY Fundings](https://intranet.uclouvain.be/fr/myucl/instituts-recherche/ipsy/formulaire-de-demande-d-indemnisation-pour-les-colloques.html)
+
+You get the grant as a refund AFTER the conference. You have to provide the certificate of attendance as well as transport ticket and hotel receipt
+
+PLEASE NOTE there is a limit of amount refundable based on the country you are traveling to. You can check the max amount at this link: 15_1.pdf (uclouvain.be)
+
+IPSY provide 700 EURO budget for PhD students who don’t have conference funding from their own scholarships.
+
+[Regulations](https://uclouvain.sharepoint.com/sites/ipsy/Documents%20partages/Forms/AllItems.aspx?id=%2Fsites%2Fipsy%2FDocuments%20partages%2FEntrep%C3%B4t%20Web%20IPSY%2FR%C3%A8glement%20attribution%20subvention%20congr%C3%A8soct%5F%5F%2Epdf&parent=%2Fsites%2Fipsy%2FDocuments%20partages%2FEntrep%C3%B4t%20Web%20IPSY)
+
+[Apply form](https://intranet.uclouvain.be/fr/myucl/instituts-recherche/ipsy/formulaire-de-demande-d-indemnisation-pour-les-colloques.html)
+
+should submit one month before the conference.
+
+### WBI
+

--- a/doc/grants.md
+++ b/doc/grants.md
@@ -3,7 +3,8 @@
 [More ideas here](https://intranet.uclouvain.be/en/myucl/administrations/adre/research-funding-opportunities.html)
 
 
-Contact person at UCL can help a lot: A.D.
+Contact person at UCL can help a lot: Anouk Distelman
+
 
 Credits / money for PhD students is rolled over from one year to the next
 
@@ -11,18 +12,14 @@ Credits / money for PhD students is rolled over from one year to the next
 
 ### FNRS
 
-
-2 months in advance for within EU, 3 months for outside EU
-
-
-**don’t need to be FNRS to apply**
-
-
-Provide max. 2 conference grants per institute
+- 2 months in advance for within EU, 3 months for outside EU
+- **don’t need to be FNRS to apply**
+- Provide max. 2 conference grants per institute
 
 [FNRS Mobilité](https://www.frs-fnrs.be/fr/financements/mobilite-monde)
 
 **PLEASE NOTE they deadline is very strict! No possibility to apply if you miss the deadline**
+
 
 ### IPSY
 


### PR DESCRIPTION
I copied and pasted the grant text from google drive. I did not put the full name of the UCL admin person responsible for the grants, just the initials (confidentiality?).  I have updated the FNRS grants link. 
However, the “fundings” and “application form” links for IPSY are the same, and I haven't found a specific link for UCL funding. There was no information in the drive about WBI grants.